### PR TITLE
Fixed R. Tyler output

### DIFF
--- a/content/_data/authors/rtyler.adoc
+++ b/content/_data/authors/rtyler.adoc
@@ -5,7 +5,7 @@ github: rtyler
 blog: 'http://unethicalblogger.com'
 ---
 
-R. Tyler Croy has been part of the Jenkins project for the past seven years.
+R&#46; Tyler Croy has been part of the Jenkins project for the past seven years.
 While avoiding contributing any Java code, Tyler is involved in many of the
 other aspects of the project which keep it running, such as this website,
 infrastructure, governance, etc.

--- a/content/_partials/author.html.haml
+++ b/content/_partials/author.html.haml
@@ -15,8 +15,8 @@
           - else
             %img.author.logo{:src => "/images/logos/transparent/transparent.svg", :alt => author.name}
         %td
-          = display_author_for(page)
-          %br
+          %h4= author.name
+          %p
           - if author.content.empty?
             This author has no biography defined.
             See social media links referenced below.


### PR DESCRIPTION
@oleg-nenashev 
This remove the link for the author's name, which doesn't make sense here and replaces it with an h4 element. 
Also fixed "R. Tyler" output as the "R." was reporting errors from asciidoc. 
https://github.com/jenkins-infra/jenkins.io/pull/1168